### PR TITLE
Remove default parameter on Vector constructor causing ambiguous overload resolution

### DIFF
--- a/Include/rtmcpp/Vector.hpp
+++ b/Include/rtmcpp/Vector.hpp
@@ -56,9 +56,9 @@ RTMCPP_EXPORT namespace rtmcpp {
 			Value = rtm::vector_set(x, y, z, w);
 		}
 
-		Vector(const Vector<ComponentType, 3>& xyz, ComponentType w = ComponentType(0)) noexcept requires(ComponentCount >= 3)
+		Vector(const Vector<ComponentType, 3>& xyz, ComponentType w) noexcept requires(ComponentCount == 4)
 		{
-			Value = rtm::vector_set(xyz.X, xyz.Y, xyz.Z, 0.0f);
+			Value = rtm::vector_set(xyz.X, xyz.Y, xyz.Z, w);
 		}
 
 		Vector(const Vector& other) noexcept


### PR DESCRIPTION
Copy constructor
```
Vector(const Vector& other) noexcept
    : Value(rtm::vector_set(other.X, other.Y, other.Z, other.W))
{
}
```
was ambiguous with constructor
```
Vector(const Vector<ComponentType, 3>& xyz, ComponentType w = ComponentType(0)) noexcept requires(ComponentCount >= 3)
{
    Value = rtm::vector_set(xyz.X, xyz.Y, xyz.Z, 0.0f);
}
```
making it impossible to store a Vector as a member of any type that requires copyability. Overload resolution is fixed by removal of the defaulted w component on the second constructor.